### PR TITLE
Fix 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,15 @@ jobs:
         uses: actions/cache@v1
         id: cache
         with:
-          path: .cache/pip
+          path: |
+            .cache/pip
+            eggs
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'constraints.txt', 'buildout.cfg', 'setup.*') }}
           restore-keys: |
             ${{ runner.os }}-test
       - name: Install dependencies
         run: |
-          pip install -U pip
+          pip install --user -U pip
           pip install -r requirements.txt -c constraints.txt
           buildout
       - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version:
+        - "2.7"
+        - "3.5"
+        - "3.6"
+        - "3.7"
+        - "3.8"
+        os:
+        - ubuntu-latest
+        - windows-latest
+        - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache packages
+        uses: actions/cache@v1
+        id: cache
+        with:
+          path: .cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'constraints.txt', 'buildout.cfg', 'setup.*') }}
+          restore-keys: |
+            ${{ runner.os }}-test
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -r requirements.txt -c constraints.txt
+          buildout
+      - name: Run Tests
+        run: |
+          ./bin/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-latest
+        # - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         python-version:
         - "2.7"
-        - "3.5"
         - "3.6"
         - "3.7"
         - "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
         id: cache
         with:
           path: |
-            .cache/pip
-            eggs
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'constraints.txt', 'buildout.cfg', 'setup.*') }}
+            ${{ github.workspace }}/.cache/pip
+            ${{ github.workspace }}/eggs
+          key: ${{ runner.os }}-test-${{ hashFiles('requirements.txt', 'constraints.txt', 'buildout.cfg', 'setup.*') }}
           restore-keys: |
             ${{ runner.os }}-test
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@ man
 parts
 
 __pycache__
-.*
+.*.cfg
 *.dll
 *.pyc
 *.pyo
 *.so
 *.egg-info/
+*.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
+    - python: "3.8"
       dist: xenial
       sudo: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 sudo: false
+dist: bionic
+cache: pip
 matrix:
   include:
     - python: "2.7"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
-      dist: xenial
-      sudo: true
 install:
-    - pip install -U setuptools zc.buildout
+    - pip install -r requirements.txt
     - buildout
 script:
     - bin/test -v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 matrix:
   include:
     - python: "2.7"
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changes
 0.8.1 (unreleased)
 ------------------
 
+- Add Github Actions testrunners for ``ubuntu``, ``windows`` and ``macos``.
+  [jensens]
+
+- Run tests with Zope 4.5.
+  [jensens]
+
 - Test/support for Python 3.8.
   [jensens]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-0.8.1 (unreleased)
+1.0.0 (unreleased)
 ------------------
 
 - Add Github Actions testrunners for ``ubuntu``, ``windows`` and ``macos``.
@@ -10,7 +10,7 @@ Changes
 - Run tests with Zope 4.5.
   [jensens]
 
-- Test/support for Python 3.8.
+- Breaking: Add and test/support for Python 3.8. Drop support for Python 3.5.
   [jensens]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 0.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Test/support for Python 3.8.
+  [jensens]
 
 
 0.8 (2018-11-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.0.0 (unreleased)
 ------------------
 
+- Fix tests to run on ``windows``.
+  [jensens]
+
 - Add Github Actions testrunners for ``ubuntu``, ``windows`` and ``macos``.
   [jensens]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.0.0 (unreleased)
 ------------------
 
+- Breaking: Remove long deprecated backward compatibility imports of getSite and setHooks.
+  [jensens]
+
 - Fix #8:  Broken on Windows (non case-sensitive filesystem).
   [jensens]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.0.0 (unreleased)
 ------------------
 
+- Fix #8:  Broken on Windows (non case-sensitive filesystem).
+  [jensens]
+
 - Fix tests to run on ``windows``.
   [jensens]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://zopefoundation.github.io/Zope/releases/4.0b6/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.5/versions-prod.cfg
 
 develop = .
 parts = test

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+-c https://zopefoundation.github.io/Zope/releases/4.5/constraints.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-r https://zopefoundation.github.io/Zope/releases/4.5/requirements-full.txt
+zc.buildout

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     keywords='page template override',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
-    url='https://pypi.org/project/z3c.jbot',
+    url='https://github.com/zopefoundation/z3c.jbot',
     license='ZPL 2.1',
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '0.8.1.dev0'
+__version__ = '1.0.0.dev0'
 
 setup(
     name='z3c.jbot',
@@ -18,7 +18,6 @@ setup(
         'License :: OSI Approved :: Zope Public License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='page template override',
     author='Zope Foundation and Contributors',

--- a/src/z3c/jbot/README.rst
+++ b/src/z3c/jbot/README.rst
@@ -14,8 +14,8 @@ It works with templates which are defined as an attribute on a view::
 To render the template, we instantiate the view and call the
 ``template`` attribute.
 
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
 
 Providing a template override
 -----------------------------
@@ -45,8 +45,8 @@ not affect the result. We register the system temporary directory::
 
 We should now see that the new filename will be used for rendering::
 
-  >>> view.template()
-  u'Override from ./interface.\n'
+  >>> print(view.template())
+  Override from ./interface.
 
 Before we proceed we'll clean up::
 
@@ -54,13 +54,13 @@ Before we proceed we'll clean up::
 
 The template does indeed render the original template::
 
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
 
 Upon rendering, the global template manager will have reverted the
 template filename to the original::
 
-  >>> view.template.filename
+  >>> view.template.filename.replace("\\", "/")
   '.../z3c/jbot/tests/templates/example.pt'
 
 Overrides can be registered for a specific layer. Let's register three
@@ -93,16 +93,18 @@ This participation does not provide even the basic request interface::
 
 We don't expect the template to be overriden for this interaction::
 
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
+  <BLANKLINE>
 
 Let's upgrade it::
 
   >>> request = participation
   >>> interface.alsoProvides(request, IRequest)
 
-  >>> view.template()
-  u'Override from ./request.\n'
+  >>> print(view.template())
+  Override from ./request.
+  <BLANKLINE>
 
   >>> view.template._v_cooked
   1
@@ -110,8 +112,9 @@ Let's upgrade it::
 Going back to a basic request::
 
   >>> interface.noLongerProvides(request, IRequest)
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
+  <BLANKLINE>
 
 Let's verify that we only cook once per template source::
 
@@ -124,35 +127,40 @@ Let's verify that we only cook once per template source::
   >>> view.template._v_last_read and view.template._v_cooked
   1
 
-  >>> view.template()
-  u'Override from ./request.\n'
+  >>> print(view.template())
+  Override from ./request.
+  <BLANKLINE>
 
 Now, if we switch to the HTTP-layer::
 
   >>> interface.noLongerProvides(request, IRequest)
   >>> interface.alsoProvides(request, IHTTPRequest)
 
-  >>> view.template()
-  u'Override from ./request.\n'
+  >>> print(view.template())
+  Override from ./request.
+  <BLANKLINE>
 
   >>> general.unregisterAllDirectories()
 
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
+  <BLANKLINE>
 
   >>> http = handler("%s/overrides/http" % directory, IHTTPRequest)
   >>> https = handler("%s/overrides/https" % directory, IHTTPSRequest)
 
-  >>> view.template()
-  u'Override from ./http.\n'
+  >>> print(view.template())
+  Override from ./http.
+  <BLANKLINE>
 
 Switching to HTTPS::
 
   >>> interface.noLongerProvides(request, IHTTPRequest)
   >>> interface.alsoProvides(request, IHTTPSRequest)
 
-  >>> view.template()
-  u'Override from ./https.\n'
+  >>> print(view.template())
+  Override from ./https.
+  <BLANKLINE>
 
   >>> interface.noLongerProvides(request, IHTTPSRequest)
 
@@ -166,8 +174,9 @@ Unregister all directories (cleanup)::
 
 The override is no longer in effect::
 
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
+  <BLANKLINE>
 
 Configuring template override directories in ZCML
 -------------------------------------------------
@@ -189,23 +198,26 @@ Let's try registering the directory again::
 
 Once again, the override will be in effect::
 
-  >>> view.template()
-  u'Override from ./interface.\n'
+  >>> print(view.template())
+  Override from ./interface.
+  <BLANKLINE>
 
 Providing the HTTP-request layer does not change this::
 
   >>> interface.alsoProvides(request, IHTTPRequest)
 
-  >>> view.template()
-  u'Override from ./interface.\n'
+  >>> print(view.template())
+  Override from ./interface.
+  <BLANKLINE>
 
 Unregister overrides::
 
   >>> for manager in z3c.jbot.utility.getManagers(IHTTPRequest):
   ...     manager.unregisterAllDirectories()
 
-  >>> view.template()
-  u'This is an example page template.\n'
+  >>> print(view.template())
+  This is an example page template.
+  <BLANKLINE>
 
 Let's register overrides for the HTTP-request layer::
 
@@ -219,5 +231,6 @@ Let's register overrides for the HTTP-request layer::
 
 Since we now provide the HTTP-request layer, the override is used::
 
-  >>> view.template()
-  u'Override from ./http.\n'
+  >>> print(view.template())
+  Override from ./http.
+  <BLANKLINE>

--- a/src/z3c/jbot/README.rst
+++ b/src/z3c/jbot/README.rst
@@ -4,7 +4,7 @@ z3c.jbot
 The z3c.jbot (or "Just a bunch of templates") package allows drop-in
 page template overrides.
 
-It works with templates which are defined as an attribute on a view.
+It works with templates which are defined as an attribute on a view::
 
   >>> from zope.pagetemplate.pagetemplatefile import PageTemplateFile
   >>> class View(object):
@@ -25,40 +25,40 @@ template override directories.
 
 If we register the directory where it's placed with the global template
 manager, it will be used when rendering this template object instead
-of the original filename.
+of the original filename::
 
   >>> import z3c.jbot.tests
   >>> directory = z3c.jbot.tests.__path__[0]
 
 Register overrides directory (by default for any request); we confirm
-that it's registered for the same template manager.
+that it's registered for the same template manager::
 
   >>> from z3c.jbot.metaconfigure import handler
   >>> manager = handler("%s/overrides/interface" % directory, interface.Interface)
 
 We make sure that the presence of an additional, trivial manager, does
-not affect the result. We register the system temporary directory:
+not affect the result. We register the system temporary directory::
 
   >>> import tempfile
   >>> handler(tempfile.tempdir, interface.Interface)
   <z3c.jbot.manager.TemplateManager object at ...>
 
-We should now see that the new filename will be used for rendering:
+We should now see that the new filename will be used for rendering::
 
   >>> view.template()
   u'Override from ./interface.\n'
 
-Before we proceed we'll clean up.
+Before we proceed we'll clean up::
 
   >>> manager.unregisterAllDirectories()
 
-The template does indeed render the original template.
+The template does indeed render the original template::
 
   >>> view.template()
   u'This is an example page template.\n'
 
 Upon rendering, the global template manager will have reverted the
-template filename to the original.
+template filename to the original::
 
   >>> view.template.filename
   '.../z3c/jbot/tests/templates/example.pt'
@@ -66,18 +66,18 @@ template filename to the original.
 Overrides can be registered for a specific layer. Let's register three
 more overrides, one for the general-purpose ``IRequest`` layer, one
 for the ``IHTTPRequest`` layer and one for a made-up ``IHTTPSRequest``
-layer.
+layer::
 
   >>> from zope.publisher.interfaces import IRequest
   >>> from zope.publisher.interfaces.http import IHTTPRequest
   >>> class IHTTPSRequest(IRequest):
   ...     """An HTTPS request."""
 
-Next we register an overrides directory for the ``IRequest`` layer.
+Next we register an overrides directory for the ``IRequest`` layer::
 
   >>> general = handler("%s/overrides/request" % directory, IRequest)
 
-Let's set up an interaction with a trivial participation.
+Let's set up an interaction with a trivial participation::
 
   >>> class Participation:
   ...     interaction = None
@@ -86,17 +86,17 @@ Let's set up an interaction with a trivial participation.
   >>> import zope.security.management
   >>> zope.security.management.newInteraction(participation)
 
-This participation does not provide even the basic request interface.
+This participation does not provide even the basic request interface::
 
   >>> IRequest.providedBy(participation)
   False
 
-We don't expect the template to be overriden for this interaction.
+We don't expect the template to be overriden for this interaction::
 
   >>> view.template()
   u'This is an example page template.\n'
 
-Let's upgrade it.
+Let's upgrade it::
 
   >>> request = participation
   >>> interface.alsoProvides(request, IRequest)
@@ -107,13 +107,13 @@ Let's upgrade it.
   >>> view.template._v_cooked
   1
 
-Going back to a basic request.
+Going back to a basic request::
 
   >>> interface.noLongerProvides(request, IRequest)
   >>> view.template()
   u'This is an example page template.\n'
 
-Let's verify that we only cook once per template source.
+Let's verify that we only cook once per template source::
 
   >>> output = view.template()
   >>> view.template._v_last_read and view.template._v_cooked
@@ -127,7 +127,7 @@ Let's verify that we only cook once per template source.
   >>> view.template()
   u'Override from ./request.\n'
 
-Now, if we switch to the HTTP-layer.
+Now, if we switch to the HTTP-layer::
 
   >>> interface.noLongerProvides(request, IRequest)
   >>> interface.alsoProvides(request, IHTTPRequest)
@@ -146,7 +146,7 @@ Now, if we switch to the HTTP-layer.
   >>> view.template()
   u'Override from ./http.\n'
 
-Switching to HTTPS.
+Switching to HTTPS::
 
   >>> interface.noLongerProvides(request, IHTTPRequest)
   >>> interface.alsoProvides(request, IHTTPSRequest)
@@ -156,7 +156,7 @@ Switching to HTTPS.
 
   >>> interface.noLongerProvides(request, IHTTPSRequest)
 
-Unregister all directories (cleanup).
+Unregister all directories (cleanup)::
 
   >>> for manager, layer in ((http, IHTTPRequest), (https, IHTTPSRequest)):
   ...     interface.alsoProvides(request, layer)
@@ -164,7 +164,7 @@ Unregister all directories (cleanup).
   ...     manager.unregisterAllDirectories()
   ...     interface.noLongerProvides(request, layer)
 
-The override is no longer in effect.
+The override is no longer in effect::
 
   >>> view.template()
   u'This is an example page template.\n'
@@ -179,7 +179,7 @@ to register template overrides directories in configuration files.
   >>> from zope.configuration import xmlconfig
   >>> xmlconfig.XMLConfig('meta.zcml', z3c.jbot)()
 
-Let's try registering the directory again.
+Let's try registering the directory again::
 
   >>> xmlconfig.xmlconfig(StringIO("""
   ... <configure xmlns="http://namespaces.zope.org/browser">
@@ -187,19 +187,19 @@ Let's try registering the directory again.
   ... </configure>
   ... """ % directory))
 
-Once again, the override will be in effect.
+Once again, the override will be in effect::
 
   >>> view.template()
   u'Override from ./interface.\n'
 
-Providing the HTTP-request layer does not change this.
+Providing the HTTP-request layer does not change this::
 
   >>> interface.alsoProvides(request, IHTTPRequest)
 
   >>> view.template()
   u'Override from ./interface.\n'
 
-Unregister overrides.
+Unregister overrides::
 
   >>> for manager in z3c.jbot.utility.getManagers(IHTTPRequest):
   ...     manager.unregisterAllDirectories()
@@ -207,7 +207,7 @@ Unregister overrides.
   >>> view.template()
   u'This is an example page template.\n'
 
-Let's register overrides for the HTTP-request layer.
+Let's register overrides for the HTTP-request layer::
 
   >>> xmlconfig.xmlconfig(StringIO("""
   ... <configure xmlns="http://namespaces.zope.org/browser">
@@ -217,7 +217,7 @@ Let's register overrides for the HTTP-request layer.
   ... </configure>
   ... """ % directory))
 
-Since we now provide the HTTP-request layer, the override is used.
+Since we now provide the HTTP-request layer, the override is used::
 
   >>> view.template()
   u'Override from ./http.\n'

--- a/src/z3c/jbot/metaconfigure.py
+++ b/src/z3c/jbot/metaconfigure.py
@@ -33,9 +33,9 @@ def handler(directory, layer):
             factory, (layer,), interfaces.ITemplateManager, name=name
         )
 
-    factory(layer).registerDirectory(directory)
-
-    return factory(layer)
+    template_manager = factory(layer)
+    template_manager.registerDirectory(directory)
+    return template_manager
 
 
 def templateOverridesDirective(_context, directory, layer=interface.Interface):

--- a/src/z3c/jbot/tests/test_doctests.py
+++ b/src/z3c/jbot/tests/test_doctests.py
@@ -16,21 +16,14 @@ OPTIONFLAGS = (
 
 
 class Py23DocChecker(doctest.OutputChecker):
+
     def check_output(self, want, got, optionflags):
-        # fix windows line-endings to match ones in tests
-        got = got.replace(r"\r\n", r"\n")
         # fix binary/unicode differences between python versions
         if six.PY2:
             want = re.sub("b'(.*?)'", "'\\1'", want)
         else:
             want = re.sub("u'(.*?)'", "'\\1'", want)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
-
-    def output_difference(self, example, got, optionflags):
-        # fix windows line-endings to match ones in tests
-        got = got.replace(r"\r\n", r"\n")
-        return doctest.OutputChecker.output_difference(
-            self, example, got, optionflags)
 
 
 def test_suite():

--- a/src/z3c/jbot/tests/test_doctests.py
+++ b/src/z3c/jbot/tests/test_doctests.py
@@ -40,7 +40,7 @@ def test_suite():
 
     return unittest.TestSuite((
         doctest.DocFileSuite(
-            'README.txt',
+            'README.rst',
             optionflags=OPTIONFLAGS,
             setUp=setUp,
             tearDown=tearDown,

--- a/src/z3c/jbot/tests/test_doctests.py
+++ b/src/z3c/jbot/tests/test_doctests.py
@@ -20,6 +20,7 @@ class Py23DocChecker(doctest.OutputChecker):
             want = re.sub("b'(.*?)'", "'\\1'", want)
         else:
             want = re.sub("u'(.*?)'", "'\\1'", want)
+        want = want.replace(r"\r\n", r"\n")
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/src/z3c/jbot/tests/test_doctests.py
+++ b/src/z3c/jbot/tests/test_doctests.py
@@ -10,18 +10,27 @@ import zope.interface
 from .common import setUp
 from .common import tearDown
 
-OPTIONFLAGS = (doctest.ELLIPSIS |
-               doctest.NORMALIZE_WHITESPACE)
+OPTIONFLAGS = (
+    doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+)
 
 
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
+        # fix windows line-endings to match ones in tests
+        got = got.replace(r"\r\n", r"\n")
+        # fix binary/unicode differences between python versions
         if six.PY2:
             want = re.sub("b'(.*?)'", "'\\1'", want)
         else:
             want = re.sub("u'(.*?)'", "'\\1'", want)
-        want = want.replace(r"\r\n", r"\n")
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
+
+    def output_difference(self, example, got, optionflags):
+        # fix windows line-endings to match ones in tests
+        got = got.replace(r"\r\n", r"\n")
+        return doctest.OutputChecker.output_difference(
+            self, example, got, optionflags)
 
 
 def test_suite():

--- a/src/z3c/jbot/tests/test_five.py
+++ b/src/z3c/jbot/tests/test_five.py
@@ -36,10 +36,7 @@ class FiveTests(ZopeTestCase):
             REQUEST = TestRequest("en")
             getSiteManager = component.getSiteManager
 
-        try:
-            from zope.site.hooks import setHooks, setSite
-        except ImportError:
-            from zope.app.component.hooks import setHooks, setSite
+        from zope.component.hooks import setHooks, setSite
 
         setHooks()
         setSite(MockSite())

--- a/src/z3c/jbot/utility.py
+++ b/src/z3c/jbot/utility.py
@@ -1,15 +1,12 @@
 from z3c.jbot.interfaces import ITemplateManager
 from zope.component import getGlobalSiteManager
+from zope.component.hooks import getSite
 from zope.interface import Interface
 from zope.interface import providedBy
 from zope.publisher.interfaces import IRequest
 import zope.security.interfaces
 import zope.security.management
 
-try:
-    from zope.site.hooks import getSite
-except ImportError:
-    from zope.app.component.hooks import getSite
 
 try:
     import Acquisition  # noqa


### PR DESCRIPTION
fixes #8 
includes #9 

- Normalize all filenames/ paths using `os.path.normcase ` and `os.path.normpath` where necessary.
- Fix doctest to be more robust with line-endings (use more print)
- Fix doctest to normalize path output to unix-style for comparision.
- Fix/ optimize runner cache.

For details see `CHANGES.rst` and single commits.
