### PR TITLE
Add support for Plone resource overrides

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changes
 =======
 
-1.0.1 (unreleased)
+1.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added support for static resource registered using the "static"
+  directive of `plone.resource`.
+  [malthe]
 
 
 1.0.0 (2020-08-25)

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,12 @@ CMF objects
 Any skin-object (e.g. images, templates) on the file system (directory
 views) can be overridden.
 
+Plone resources
+---------------
+
+If `plone.resource` is installed, it's possible to use jbot to
+override filesystem resources.
+
 Author
 ------
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,11 +1,15 @@
 [buildout]
 extends =
-    https://zopefoundation.github.io/Zope/releases/4.5/versions-prod.cfg
+    https://dist.plone.org/release/5-latest/versions.cfg
 
 develop = .
 parts = test
+versions = versions
 
 [test]
 recipe = zc.recipe.testrunner
 eggs =
     z3c.jbot[test]
+
+[versions]
+z3c.jbot =

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.1.dev0'
+__version__ = '1.1.0.dev'
 
 setup(
     name='z3c.jbot',
@@ -43,7 +43,12 @@ setup(
         'zope.publisher',
     ],
     extras_require={
-        'test': ['Zope2'],
+        'test': [
+            'Zope2',
+            'Products.BTreeFolder2',
+            'Products.CMFCore',
+            'plone.resource',
+        ],
     },
     entry_points="""
     [z3c.autoinclude.plugin]

--- a/src/z3c/jbot/browser.py
+++ b/src/z3c/jbot/browser.py
@@ -1,0 +1,36 @@
+from zope.interface import implementer, providedBy
+from zope.publisher.interfaces.browser import IBrowserPublisher
+
+try:
+    from plone.resource.file import FilesystemFile
+    HAS_PLONE_RESOURCE = True
+except ImportError:
+    HAS_PLONE_RESOURCE = False
+
+from .utility import getManagers
+
+
+@implementer(IBrowserPublisher)
+class FilesystemFileResourceBrowserPublisher(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def browserDefault(self, request):
+        assert HAS_PLONE_RESOURCE
+        layer = providedBy(request)
+        for manager in getManagers(layer):
+            path = manager.queryResourcePath(self.context)
+            if path is not None:
+                resource = FilesystemFile(
+                    self.context.__parent__,
+                    request,
+                    path,
+                    self.context.__name__,
+                )
+                break
+        else:
+            resource = self.context
+
+        return resource, ()
+

--- a/src/z3c/jbot/tests/overrides/resources/z3c.jbot.tests.resources.test.txt
+++ b/src/z3c/jbot/tests/overrides/resources/z3c.jbot.tests.resources.test.txt
@@ -1,0 +1,1 @@
+Override

--- a/src/z3c/jbot/tests/resources/test.txt
+++ b/src/z3c/jbot/tests/resources/test.txt
@@ -1,0 +1,1 @@
+Original


### PR DESCRIPTION
This adds support for overriding static resources as registered by [plone.resource](https://pypi.org/project/plone.resource/).

Note that in principle this could live in a new "plone.jbot" package, but since we already have support for Zope 2 CMF objects (when Zope 2 is present), it is considered to be a reasonable inclusion here.