### PR TITLE
fix find_zope2_product error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changes
 
 In next release ...
 
--
+- Fix error in find_zope2_product: "TypeError: expected str, bytes or os.PathLike object, not list".
+  [jensens]
 
 1.1.0 (2020-09-20)
 ------------------

--- a/src/z3c/jbot/manager.py
+++ b/src/z3c/jbot/manager.py
@@ -13,14 +13,13 @@ DELETE = object()
 
 
 def normalize(filepath):
-    return(os.path.normcase(os.path.normpath(filepath)))
+    return os.path.normcase(os.path.normpath(filepath))
 
 
 def root_length(a, b):
     if b.startswith(a):
         return len(a)
-    else:
-        return 0
+    return 0
 
 
 def sort_by_path(path, paths):
@@ -32,13 +31,14 @@ def sort_by_path(path, paths):
 def find_zope2_product(path):
     """Check the Zope2 magic Products semi-namespace to see if the
     path is part of a Product."""
+    _syspaths = sort_by_path(
+        path, 
+        [normalize(path) for path in sys.modules["Products"].__path__],
+    )
+    syspath = _syspaths[0]
 
-    _syspaths = sort_by_path(path, normalize(sys.modules["Products"].__path__))
-    syspath = syspaths[0]
-
-    path = path
     if not path.startswith(syspath):
-        return None
+        return
 
     product = path[len(syspath) + 1 :].split(os.path.sep, 2)[0]
 


### PR DESCRIPTION
While accessing a resources directory registered with `plone.resource` I got:

```
2021-04-13 17:03:33,150 ERROR   [Zope.SiteErrorLog:252][waitress-1] 1618326213.149810.72209773518247 http://localhost:8080/Plone/++documentation++html/index.html
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 250, in publish
  Module ZPublisher.BaseRequest, line 486, in traverse
  Module z3c.jbot.browser, line 23, in browserDefault
  Module z3c.jbot.manager, line 178, in queryResourcePath
  Module z3c.jbot.manager, line 58, in find_package
  Module z3c.jbot.manager, line 36, in find_zope2_product
  Module z3c.jbot.manager, line 16, in normalize
  Module posixpath, line 336, in normpath
TypeError: expected str, bytes or os.PathLike object, not list
```

This change fixes the problem.