### PR TITLE
fix: Fix error when Plone site is not yet set as in first index_html call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changes
 =======
 
-2.1 (unreleased)
+2.0.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix error when Plone site is not yet set as in first index_html call on Zope.
+  [bsuttor]
 
 
 2.0 (2023-05-04)

--- a/src/z3c/jbot/utility.py
+++ b/src/z3c/jbot/utility.py
@@ -11,7 +11,6 @@ from z3c.jbot.interfaces import ITemplateManager
 
 try:
     import Acquisition  # noqa
-    import Zope2  # noqa
     ZOPE_3 = False
 except ImportError:
     ZOPE_3 = True
@@ -25,7 +24,7 @@ def getRequest():
             try:
                 return site.request
             except AttributeError:
-                return getattr(site, "REQUEST", Zope2.app().REQUEST)
+                return None
 
     try:
         i = zope.security.management.getInteraction()

--- a/src/z3c/jbot/utility.py
+++ b/src/z3c/jbot/utility.py
@@ -24,7 +24,7 @@ def getRequest():
             try:
                 return site.request
             except AttributeError:
-                return None
+                return getattr(site, "REQUEST", None)
 
     try:
         i = zope.security.management.getInteraction()

--- a/src/z3c/jbot/utility.py
+++ b/src/z3c/jbot/utility.py
@@ -11,6 +11,7 @@ from z3c.jbot.interfaces import ITemplateManager
 
 try:
     import Acquisition  # noqa
+    import Zope2  # noqa
     ZOPE_3 = False
 except ImportError:
     ZOPE_3 = True
@@ -24,7 +25,7 @@ def getRequest():
             try:
                 return site.request
             except AttributeError:
-                return site.REQUEST
+                return getattr(site, "REQUEST", Zope2.app().REQUEST)
 
     try:
         i = zope.security.management.getInteraction()


### PR DESCRIPTION
In first index_html call on Zope, for example on http://localhost:8080/index_html, REQUEST for Plone Site is not yet set.
If you go directly on Plone, for example on http://localhost:8080/Plone/index_html, request is set to Plone Site (by acquisition) and you have not this error.
```
    ...
    z3c.jbot-2.0-py3.10.egg/z3c/jbot/utility.py", line 27, in getRequest
    return site.REQUEST
AttributeError: REQUEST

```

This fix is only usefull for first call on http://localhost:8080/index_html
