### PR TITLE
Add a ``jbot-deprecations`` ZCML feature to conditionally set depreca…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changes
   override for the old template path to still work.
   [maurits]
 
+- Add a ``jbot-deprecations`` ZCML feature to conditionally set deprecations.
+  [ale-rt]
+
 
 2.1 (2024-11-29)
 ----------------

--- a/src/z3c/jbot/meta.zcml
+++ b/src/z3c/jbot/meta.zcml
@@ -2,6 +2,8 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:meta="http://namespaces.zope.org/meta">
 
+    <meta:provides feature="jbot-deprecations" />
+
     <meta:directives namespace="http://namespaces.zope.org/browser">
 
       <meta:directive

--- a/src/z3c/jbot/tests/test_five.py
+++ b/src/z3c/jbot/tests/test_five.py
@@ -102,6 +102,25 @@ class FiveTests(ZopeTestCase):
         noLongerProvides(self._request, IHTTPSRequest)
         self.assertEqual(self._view.template(), self._interface_override)
 
+    def test_zcml_features(self):
+        from zope.configuration import xmlconfig
+        from zope.configuration.config import ConfigurationMachine
+
+        context = ConfigurationMachine()
+        xmlconfig.registerCommonDirectives(context)
+
+        xmlconfig.string(
+            """
+            <configure
+                xmlns="http://namespaces.zope.org/zope"
+            >
+                <include package="z3c.jbot" file="meta.zcml" />
+            </configure>
+            """, context=context
+        )
+
+        self.assertTrue(context.hasFeature("jbot-deprecations"))
+
     def test_deprecated_override(self):
         from unittest.mock import patch
 


### PR DESCRIPTION
…tions.

This is useful to write create jbot deprecations warnings that will not break without forcing to update z3c.jbot